### PR TITLE
LINE Botで手紙を作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,8 @@ gem 'html2slim'
 # line
 gem 'line-bot-api'
 
+# Background Job
+gem 'whenever', require: false
 
 group :development, :test do
   #Debugger

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crass (1.0.6)
@@ -305,6 +306,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.5.4)
@@ -348,6 +351,7 @@ DEPENDENCIES
   tzinfo-data
   web-console (>= 4.1.0)
   webpacker (~> 5.0)
+  whenever
 
 RUBY VERSION
    ruby 2.6.5p114

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -1,33 +1,173 @@
 class LinebotController < ApplicationController
   protect_from_forgery :except => [:callback]
-  require 'line/bot'
-
 
   def callback
+    # リクエストのヘッダー署名情報を取得
     body = request.body.read
+    # 署名検証
     signature = request.env['HTTP_X_LINE_SIGNATURE']
     unless client.validate_signature(body, signature)
       error 400 do 'Bad Request' end
     end
+    # リクエストボディのみ取得
     events = client.parse_events_from(body)
-
-    # evnets内のtypeを識別していく。
     events.each do |event|
       case event
+      # MessageでWebhookが送られた場合
       when Line::Bot::Event::Message
         case event.type
-        # 今回はメッセージに対応する処理を行うため、type: "text"の場合処理をする。
-        # 例えば位置情報に対応する処理を行うためには、MessageType::Locationとなる。
         when Line::Bot::Event::MessageType::Text
-          message = {
-            type: 'text',
-            #送られた内容をそのまま返す
-            text: event.message['text']
-          }
+          # ユーザを特定
+          @user = User.find_by(line_id: event['source']['userId'])
+          if @user.nil?
+            message = {
+              type: 'text',
+              text: 'メニューバーからユーザ登録を行ってください'
+            }
+            client.reply_message(event['replyToken'], message)
+          end
+          # 送られてきたメッセージを格納
+          replied_message = event.message['text']
+          # 手紙を登録する前にnewでインスタンスに格納しておく
+          if @user.letter_status == 'before_message_registration'
+            @letter = Letter.new(user_id: @user.id, message: replied_message, dig: 0)
+          end
+
+          # 手紙を登録するやりとりをステータスごとに分けて処理
+          case @user.letter_status
+          # 手紙の内容（メッセージ）を送ってくるようにアナウンスする処理
+          when 'send_message'
+            if replied_message == '手紙'
+              message = {
+                type: 'text',
+                text: '未来の自分に向けてのメッセージを送ってください'
+              }
+              client.reply_message(event['replyToken'], message)
+              @user.before_message_registration!
+            else
+              message = {
+                type: 'text',
+                text: 'メニューバーから「手紙」「記録」を選択して、未来の自分にメッセージを送ろう'
+              }
+              client.reply_message(event['replyToken'], message)
+            end
+          # メッセージを登録する前に内容が正確かを確認する処理
+          when 'before_message_registration'
+            message = {
+              type: 'text',
+              text: "以下のメッセージで登録してよろしいですか？\n\n"+ replied_message,
+              quickReply: {
+                items: [
+                  {
+                    type: 'action',
+                    action: {
+                      type: "postback",
+                      label: "はい",
+                      data: replied_message,
+                    },
+                  },
+                  {
+                    type: 'action',
+                    action: {
+                      type: "postback",
+                      label: "いいえ",
+                      data: "rEsTaRt",
+                    }
+                  }
+                ]
+              }
+            }
+            client.reply_message(event['replyToken'], message)
+            @user.message_registration!
+          # 表示されたアクションを選択せずに、メッセージが送られたときの処理
+          when 'message_registration'
+            message = {
+              type: "text",
+              text: "再度、未来の自分に向けてのメッセージを送ってください"
+            }
+            client.reply_message(event['replyToken'], message)
+            @user.before_message_registration!
+          # 登録されたデータの内容を表示する処理
+          when 'dig_registration'
+            message = {
+              type: 'text',
+              text: "「手紙」を登録しました！\n\n手紙は○○に届きます。"
+            }
+            client.reply_message(event['replyToken'], message)
+            @user.send_message!
+          end
+        end
+
+      # PostbackでWebhookが送られた場合
+      when Line::Bot::Event::Postback
+        @user = User.find_by(line_id: event['source']['userId'])
+
+        case  @user.letter_status
+        # メッセージ確認のアクションが選択されたときの処理（手紙のデータ登録）とメッセージが届けられる日程を選択
+        when 'message_registration'
+          if event['postback']['data'] != 'rEsTaRt'
+            @letter = Letter.create(user_id: @user.id, message: event['postback']['data'], dig: 0)
+            puts @letter
+            message = {
+              type: 'text',
+              text: "手紙を届けるのはいつにしますか？",
+              quickReply: {
+                items: [
+                  {
+                    type: 'action',
+                    action: {
+                      type: 'message',
+                      label: '5分後',
+                      text: '5分後'
+                    },
+                  },
+                  {
+                    type: 'action',
+                    action: {
+                      type: 'message',
+                      label: '15分後',
+                      text: '15分後'
+                    }
+                  },
+                  {
+                    type: 'action',
+                    action: {
+                      type: 'message',
+                      label: '1時間後',
+                      text: '1時間後'
+                    }
+                  },
+                  {
+                    type: 'action',
+                    action: {
+                      type: 'message',
+                      label: '12時間後',
+                      text: '12時間後'
+                    }
+                  },
+                  {
+                    type: 'action',
+                    action: {
+                      type: 'message',
+                      label: '1日後',
+                      text: '1日後'
+                    }
+                  },
+                ]
+              }
+            }
+            client.reply_message(event['replyToken'], message)
+            @user.dig_registration!
+          else  event['postback']['data'] == 'rEsTaRt'
+            message = {
+              type: "text",
+              text: "再度、未来の自分に向けてのメッセージを送ってください"
+            }
+            client.reply_message(event['replyToken'], message)
+            @user.before_message_registration!
+          end
         end
       end
-      # 応答メッセージを送る
-      client.reply_message(event['replyToken'], message)
     end
     head :ok
   end

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -28,10 +28,6 @@ class LinebotController < ApplicationController
           end
           # 送られてきたメッセージを格納
           replied_message = event.message['text']
-          # 手紙を登録する前にnewでインスタンスに格納しておく
-          if @user.letter_status == 'before_message_registration'
-            @letter = Letter.new(user_id: @user.id, message: replied_message, dig: 0)
-          end
 
           # 手紙を登録するやりとりをステータスごとに分けて処理
           case @user.letter_status
@@ -43,7 +39,7 @@ class LinebotController < ApplicationController
                 text: '未来の自分に向けてのメッセージを送ってください'
               }
               client.reply_message(event['replyToken'], message)
-              @user.before_message_registration!
+              @user.message_registration!
             else
               message = {
                 type: 'text',
@@ -51,121 +47,51 @@ class LinebotController < ApplicationController
               }
               client.reply_message(event['replyToken'], message)
             end
-          # メッセージを登録する前に内容が正確かを確認する処理
-          when 'before_message_registration'
+          # 表示されたアクションを選択せずに、メッセージが送られたときの処理
+          when 'message_registration'
+            now = Date.today
+            min = now + 1
+            max = now >> 12
+            @letter = Letter.create(user_id: @user.id, message: replied_message, dig_notice: max)
             message = {
               type: 'text',
-              text: "以下のメッセージで登録してよろしいですか？\n\n"+ replied_message,
+              text: "明日から一年後までの間で、手紙を届ける日時を選択してください。",
               quickReply: {
                 items: [
                   {
                     type: 'action',
                     action: {
-                      type: "postback",
-                      label: "はい",
-                      data: replied_message,
-                    },
-                  },
-                  {
-                    type: 'action',
-                    action: {
-                      type: "postback",
-                      label: "いいえ",
-                      data: "rEsTaRt",
+                      type: "datetimepicker",
+                      label: "日時を選択してください。",
+                      data:  @letter.id,
+                      mode: "date",
+                      initial: min.strftime("%Y-%m-%d"),
+                      max: max.strftime("%Y-%m-%d"),
+                      min: min.strftime("%Y-%m-%d")
                     }
                   }
                 ]
               }
             }
             client.reply_message(event['replyToken'], message)
-            @user.message_registration!
-          # 表示されたアクションを選択せずに、メッセージが送られたときの処理
-          when 'message_registration'
-            message = {
-              type: "text",
-              text: "再度、未来の自分に向けてのメッセージを送ってください"
-            }
-            client.reply_message(event['replyToken'], message)
-            @user.before_message_registration!
-          # 登録されたデータの内容を表示する処理
-          when 'dig_registration'
-            message = {
-              type: 'text',
-              text: "「手紙」を登録しました！\n\n手紙は○○に届きます。"
-            }
-            client.reply_message(event['replyToken'], message)
-            @user.send_message!
+            @user.dig_registration!
           end
         end
-
       # PostbackでWebhookが送られた場合
       when Line::Bot::Event::Postback
         @user = User.find_by(line_id: event['source']['userId'])
 
         case  @user.letter_status
-        # メッセージ確認のアクションが選択されたときの処理（手紙のデータ登録）とメッセージが届けられる日程を選択
-        when 'message_registration'
-          if event['postback']['data'] != 'rEsTaRt'
-            @letter = Letter.create(user_id: @user.id, message: event['postback']['data'], dig: 0)
-            puts @letter
-            message = {
-              type: 'text',
-              text: "手紙を届けるのはいつにしますか？",
-              quickReply: {
-                items: [
-                  {
-                    type: 'action',
-                    action: {
-                      type: 'message',
-                      label: '5分後',
-                      text: '5分後'
-                    },
-                  },
-                  {
-                    type: 'action',
-                    action: {
-                      type: 'message',
-                      label: '15分後',
-                      text: '15分後'
-                    }
-                  },
-                  {
-                    type: 'action',
-                    action: {
-                      type: 'message',
-                      label: '1時間後',
-                      text: '1時間後'
-                    }
-                  },
-                  {
-                    type: 'action',
-                    action: {
-                      type: 'message',
-                      label: '12時間後',
-                      text: '12時間後'
-                    }
-                  },
-                  {
-                    type: 'action',
-                    action: {
-                      type: 'message',
-                      label: '1日後',
-                      text: '1日後'
-                    }
-                  },
-                ]
-              }
-            }
-            client.reply_message(event['replyToken'], message)
-            @user.dig_registration!
-          else  event['postback']['data'] == 'rEsTaRt'
-            message = {
-              type: "text",
-              text: "再度、未来の自分に向けてのメッセージを送ってください"
-            }
-            client.reply_message(event['replyToken'], message)
-            @user.before_message_registration!
-          end
+        # 登録されたデータの内容を表示する処理
+        when 'dig_registration'
+          @letter = Letter.find_by(id: event['postback']['data'])
+          @letter.update(dig_notice: event['postback']['params']['date'].to_date)
+          message = {
+            type: 'text',
+            text: "登録しました！\n\n登録した手紙は"+ @letter.dig_notice.strftime("%Y年%-m月%-d日") +"に届きます。\n\nお楽しみに！"
+          }
+          client.reply_message(event['replyToken'], message)
+          @user.send_message!
         end
       end
     end

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -1,0 +1,44 @@
+class LinebotController < ApplicationController
+  protect_from_forgery :except => [:callback]
+  require 'line/bot'
+
+
+  def callback
+    body = request.body.read
+    signature = request.env['HTTP_X_LINE_SIGNATURE']
+    unless client.validate_signature(body, signature)
+      error 400 do 'Bad Request' end
+    end
+    events = client.parse_events_from(body)
+
+    # evnets内のtypeを識別していく。
+    events.each do |event|
+      case event
+      when Line::Bot::Event::Message
+        case event.type
+        # 今回はメッセージに対応する処理を行うため、type: "text"の場合処理をする。
+        # 例えば位置情報に対応する処理を行うためには、MessageType::Locationとなる。
+        when Line::Bot::Event::MessageType::Text
+          message = {
+            type: 'text',
+            #送られた内容をそのまま返す
+            text: event.message['text']
+          }
+        end
+      end
+      # 応答メッセージを送る
+      client.reply_message(event['replyToken'], message)
+    end
+    head :ok
+  end
+
+private
+
+# LINE Developers登録完了後に作成される環境変数の認証
+  def client
+    @client ||= Line::Bot::Client.new { |config|
+      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+    }
+  end
+end

--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -36,33 +36,33 @@ class LinebotController < ApplicationController
             if replied_message == '手紙'
               message = {
                 type: 'text',
-                text: '未来の自分に向けてのメッセージを送ってください'
+                text: '未来の自分に向けてのメッセージを送ろう！'
               }
               client.reply_message(event['replyToken'], message)
               @user.message_registration!
             else
               message = {
                 type: 'text',
-                text: 'メニューバーから「手紙」「記録」を選択して、未来の自分にメッセージを送ろう'
+                text: 'メニューバーから「手紙」「記録」を選択して、未来の自分にメッセージを送ろう！'
               }
               client.reply_message(event['replyToken'], message)
             end
           # 表示されたアクションを選択せずに、メッセージが送られたときの処理
           when 'message_registration'
             now = Date.today
-            min = now + 1
+            min = now >> 1
             max = now >> 12
             @letter = Letter.create(user_id: @user.id, message: replied_message, dig_notice: max)
             message = {
               type: 'text',
-              text: "明日から一年後までの間で、手紙を届ける日時を選択してください。",
+              text: "１ヶ月後から１年後までの間で、手紙を届ける日時を選択しよう！",
               quickReply: {
                 items: [
                   {
                     type: 'action',
                     action: {
                       type: "datetimepicker",
-                      label: "日時を選択してください。",
+                      label: "こちらから日時を選択してください",
                       data:  @letter.id,
                       mode: "date",
                       initial: min.strftime("%Y-%m-%d"),
@@ -88,7 +88,7 @@ class LinebotController < ApplicationController
           @letter.update(dig_notice: event['postback']['params']['date'].to_date)
           message = {
             type: 'text',
-            text: "登録しました！\n\n登録した手紙は"+ @letter.dig_notice.strftime("%Y年%-m月%-d日") +"に届きます。\n\nお楽しみに！"
+            text: "登録したよ！\n\n登録した手紙は\n"+ @letter.dig_notice.strftime("%Y年%-m月%-d日") +"に届くよ！\n\nお楽しみに！"
           }
           client.reply_message(event['replyToken'], message)
           @user.send_message!

--- a/app/models/letter.rb
+++ b/app/models/letter.rb
@@ -1,3 +1,7 @@
 class Letter < ApplicationRecord
   belongs_to :user, foreign_key: "user_id"
+
+  # 届け日となった手紙を収集
+  scope :dig_noticed, -> { where(dig_notice: Date.today) }
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,6 @@ class User < ApplicationRecord
   has_many :records, dependent: :destroy
   has_many :comments, dependent: :destroy
 
-  enum letter_status: { send_message: 0, before_message_registration: 1, message_registration: 2, dig_registration: 3 }
+  enum letter_status: { send_message: 0, message_registration: 1, dig_registration: 2 }
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,7 @@ class User < ApplicationRecord
   has_many :letters, dependent: :destroy
   has_many :records, dependent: :destroy
   has_many :comments, dependent: :destroy
+
+  enum letter_status: { send_message: 0, before_message_registration: 1, message_registration: 2, dig_registration: 3 }
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   root 'homes#top'
   get 'login', to: 'users#login'
+  post '/callback' => 'linebot#callback'
   resources :users, only: [:new, :create]
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,20 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,20 +1,13 @@
-# Use this file to easily define all of your cron jobs.
-#
-# It's helpful, but not entirely necessary to understand cron before proceeding.
-# http://en.wikipedia.org/wiki/Cron
+# Rails.rootを使用するために必要
+require File.expand_path(File.dirname(__FILE__) + "/environment")
+# cronを実行する環境変数
+rails_env = ENV['RAILS_ENV'] || :development
+# cronを実行する環境変数をセット
+set :environment, rails_env
+# cronのログの吐き出し場所
+set :output, "#{Rails.root}/log/cron.log"
 
-# Example:
-#
-# set :output, "/path/to/my/cron_log.log"
-#
-# every 2.hours do
-#   command "/usr/bin/some_great_command"
-#   runner "MyModel.some_method"
-#   rake "some:great:rake:task"
-# end
-#
-# every 4.days do
-#   runner "AnotherModel.prune_old_records"
-# end
-
-# Learn more: http://github.com/javan/whenever
+# 毎朝9時届け日に該当する手紙を送る
+every 1.day, at: ['9:00 am'] do
+  rake 'letter_summary:send_letter'
+end

--- a/db/migrate/20220410072037_create_letters.rb
+++ b/db/migrate/20220410072037_create_letters.rb
@@ -3,7 +3,7 @@ class CreateLetters < ActiveRecord::Migration[6.1]
     create_table :letters do |t|
       t.references :user, null: false, foreign_key: true
       t.text :message, null: false
-      t.integer :dig, null: false, default: 0
+      t.date :dig_notice,
 
       t.timestamps
     end

--- a/db/migrate/20220415071226_add_letter_status_to_users.rb
+++ b/db/migrate/20220415071226_add_letter_status_to_users.rb
@@ -1,0 +1,5 @@
+class AddLetterStatusToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :letter_status, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20220415071226_add_letter_status_to_users.rb
+++ b/db/migrate/20220415071226_add_letter_status_to_users.rb
@@ -1,5 +1,5 @@
 class AddLetterStatusToUsers < ActiveRecord::Migration[6.1]
   def change
-    add_column :users, :letter_status, :integer, null: false, default: 0
+    add_column :users, :letter_status, :integer, default: 0
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_10_072446) do
+ActiveRecord::Schema.define(version: 2022_04_15_071226) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2022_04_10_072446) do
     t.string "line_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "letter_status", default: 0, null: false
   end
 
   add_foreign_key "comments", "records"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,9 +28,10 @@ ActiveRecord::Schema.define(version: 2022_04_15_071226) do
   create_table "letters", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.text "message", null: false
-    t.integer "dig", default: 0, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.date "dig_notice"
+    t.date "#<ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition"
     t.index ["user_id"], name: "index_letters_on_user_id"
   end
 
@@ -48,7 +49,7 @@ ActiveRecord::Schema.define(version: 2022_04_15_071226) do
     t.string "line_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "letter_status", default: 0, null: false
+    t.integer "letter_status", default: 0
   end
 
   add_foreign_key "comments", "records"

--- a/lib/tasks/letter_summary.rake
+++ b/lib/tasks/letter_summary.rake
@@ -1,0 +1,19 @@
+namespace :letter_summary do
+  desc '本日の日付が手紙の届け日時になった時、その日のam9:00に該当する手紙を送信する'
+	task send_letter: :environment do
+		@letters = Letter.dig_noticed
+		@letters.each do |letter|
+			user = User.find_by(id: letter.user_id)
+			message = {
+				type: 'text',
+				text: "過去のあなたから手紙が届いたよ\n\n" + letter.message + "\n\n" + letter.created_at.strftime("%Y年%-m月%-d日")
+			}
+			client = Line::Bot::Client.new { |config|
+				config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+				config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+			}
+			response = client.push_message(user.line_id, message)
+			p response
+		end
+	end
+end


### PR DESCRIPTION
## 実装内容

* 追加：line-bot-apiを導入 https://github.com/O-H-K-N/line-capsule/pull/18/commits/eeb1b5226b67ce43aa94b96504e3a00a3da9147a 
* 追加：LINE Botで手紙を登録する処理を修正＋手紙が届く日を登録できるように設定 https://github.com/O-H-K-N/line-capsule/pull/18/commits/f0a5464037855d2f7491bcdeaa2a8e47ce93027d https://github.com/O-H-K-N/line-capsule/pull/18/commits/6d03a339ff5888aab311b5a75ea076b524f93f81 
* 追加：wheneverの導入 https://github.com/O-H-K-N/line-capsule/pull/18/commits/5036173486972767d3e6238065009d8dfd507481 
* 追加：wheneverを使って、届け日となった手紙を該当するユーザに自動送信する機能を実装 https://github.com/O-H-K-N/line-capsule/pull/18/commits/1260e3d4babce452626fe582cf88a05b231c9ab4 

## できるようになること（ユーザ目線）

* LINE Bot上で指示に従って「手紙」を登録できる
* 登録した手紙がBotから送信される

## できなくなること（ユーザ目線）

- LINE Bot上で手紙を送信した時点で登録されてしまうため、訂正したくてもできない
  →Webサイト上で修正or削除できる処理をもたすつもり。。。
