### PR TITLE
記録の一覧、詳細、削除機能を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 *.rbc
 capybara-*.html
 .rspec

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'pg', '~> 1.1'
 gem 'puma', '~> 5.0'
 # Use SCSS for stylesheets
 gem 'sass-rails', '>= 6'
+gem 'sassc'
 gem 'bootstrap', '>= 5'
 gem 'jquery-rails'
 gem 'font-awesome-sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,6 +341,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   sass-rails (>= 6)
+  sassc
   slim-rails
   spring
   tzinfo-data

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,3 +38,28 @@ body {
   opacity: 1;
   text-decoration: underline;
 }
+
+.dropdown{
+  min-width: 0;
+  cursor: pointer;
+
+  &-content{
+    display: none;
+    position: absolute;
+    background-color: #f8f9fa;
+    z-index: 1;
+    text-align: left;
+    text-align: center;
+    right: 0;
+
+    a{
+      opacity: 0.7;
+      text-decoration: none;
+    }
+
+    a:hover{
+      opacity: 1;
+      text-decoration: none;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,6 @@
 @import "bootstrap";
+// @import "font-awesome-sprockets";
+@import "font-awesome";
 @import "footer";
 
 body {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,7 @@
 @import "bootstrap";
 // @import "font-awesome-sprockets";
 @import "font-awesome";
-@import "footer";
+@import "header_footer";
 
 body {
   background-color: #c2d9fe;
@@ -10,7 +10,7 @@ body {
 }
 
 .wrapper{
-  margin-top: 62px;
+  margin: 62px 0px;
 }
 
 .navbar-dark .navbar-nav .nav-link{
@@ -28,4 +28,13 @@ body {
 
 .record-field{
   display: none;
+}
+
+.link{
+  opacity: 0.7;
+}
+
+.link:hover{
+  opacity: 1;
+  text-decoration: underline;
 }

--- a/app/assets/stylesheets/header_footer.scss
+++ b/app/assets/stylesheets/header_footer.scss
@@ -1,4 +1,4 @@
-nav, footer{
+nav, footer, .record_header{
   background-color: #3683ff;
 
   .nav-title, .navbar-toggler-icon{

--- a/app/controllers/letters_controller.rb
+++ b/app/controllers/letters_controller.rb
@@ -37,7 +37,7 @@ class LettersController < ApplicationController
   def letter_params
     params.require(:letter).permit(
       :message,
-      :dig_notice
+      :send_at
     )
   end
 end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -23,7 +23,7 @@ class RecordsController < ApplicationController
   end
 
   def show
-    @record = Record.find(params[:id])
+    @record = current_user.records.find(params[:id])
   end
 
   def new
@@ -37,6 +37,12 @@ class RecordsController < ApplicationController
     else
       render :new
     end
+  end
+
+  def destroy
+    record = current_user.records.find(params[:id])
+    record.destroy!
+    redirect_to records_path
   end
 
   private

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -19,7 +19,7 @@ class RecordsController < ApplicationController
   end
 
   def index
-    @records = current_user.records.all.order(created_at: :desc)
+    @records = params[:tag_id].present? ? Tag.find(params[:tag_id]).records : current_user.records.all.order(created_at: :desc)
   end
 
   def show

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -39,8 +39,9 @@ class RecordsController < ApplicationController
 
   def record_params
     params.require(:record).permit(
-      :title,
-      :content
+      :theme,
+      :content,
+      tag_ids: []
     )
   end
 end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -18,6 +18,10 @@ class RecordsController < ApplicationController
     session[:user_id] = user.id
   end
 
+  def index
+    @records = current_user.records.all.order(created_at: :desc)
+  end
+
   def show
     @record = Record.find(params[:id])
   end

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -39,7 +39,6 @@ class RecordsController < ApplicationController
 
   def record_params
     params.require(:record).permit(
-      :category,
       :title,
       :content
     )

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,15 @@
 module ApplicationHelper
+  # 記録を扱うページのヘッダーメニュー
+  def record_menu(target_action)
+    return unless params[:action] == target_action
+
+    'text-dark bg-light border border-3 rounded-2'
+  end
+
+  # 新規登録・ログイン後のフッターメニュー
   def footer_menu(target_controller)
     return unless params[:controller] == target_controller
 
-    'text-dark bg-light'
+    'text-dark bg-light border border-3 rounded-2'
   end
 end

--- a/app/javascript/packs/records/index.js
+++ b/app/javascript/packs/records/index.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', () => {
+  $('.dropdown').each(function (index, record) {
+    var recordId = $(record).attr('id');
+
+    // 各記録のメニューボタンをクリックすると、ドロップダウンメニューが表示される
+    $(`#${recordId}.dropdown`).on('click touchend', () => {
+      $(`#${recordId}.dropdown-content`).fadeIn();
+    })
+
+    // 適当に画面をタップすると、開いていたドロップダウンメニューは閉じる
+    $(document).on('click touchend', (event) => {
+      if (!$(event.target).closest(`#${recordId}.dropdown`).length) {
+        $(`#${recordId}.dropdown-content`).fadeOut();
+      }
+    });
+  })
+})

--- a/app/javascript/packs/records/show.js
+++ b/app/javascript/packs/records/show.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // メニューボタンをクリックすると、ドロップダウンメニューが表示される
+  $('.dropdown').on('click touchend', () => {
+    $('.dropdown-content').fadeIn();
+  })
+
+  // 適当に画面をタップすると、開いていたドロップダウンメニューは閉じる
+  $(document).on('click touchend', (event) => {
+    if (!$(event.target).closest('.dropdown').length) {
+      $('.dropdown-content').fadeOut();
+    }
+  });
+})

--- a/app/models/letter.rb
+++ b/app/models/letter.rb
@@ -3,19 +3,21 @@ class Letter < ApplicationRecord
 
   validates :message, presence: true
   validates :message, length: { in: 2..800 }, allow_blank: true
-  validates :dig_notice, presence: true
+  validates :send_at, presence: true
   validate :date_before_start
   validate :date_before_finish
 
   def date_before_start
-    errors.add(:dig_notice, "は明日以降のものを選択してください") if dig_notice <= Date.today
+    errors.add(:send_at, "は明日以降のものを選択してください") if send_at <= Date.today
   end
 
   def date_before_finish
-    errors.add(:dig_notice, "は本日よりも１年以内のものを選択してください") if Date.today + 1.years < dig_notice
+    errors.add(:send_at, "は本日よりも１年以内のものを選択してください") if Date.today + 1.years < send_at
   end
 
-  # 届け日となった手紙を収集
-  scope :dig_noticed, -> { where(dig_notice: Date.today) }
+  # 送付日がまだな手紙を収集
+  scope :not_sent, -> { where('send_at > ?', Date.today) }
+  # 送付日が過ぎた手紙を収集
+  scope :sent, -> { where('send_at <= ?', Date.today) }
 
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -1,4 +1,6 @@
 class Record < ApplicationRecord
+  has_many :record_tags, dependent: :destroy
+  has_many :tags, through: :record_tags
   has_many :comments, dependent: :destroy
   belongs_to :user, foreign_key: "user_id"
 

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -4,8 +4,9 @@ class Record < ApplicationRecord
   has_many :comments, dependent: :destroy
   belongs_to :user, foreign_key: "user_id"
 
+  validates :tag_ids, presence: true
   validates :theme, presence: true
   validates :theme, length: { in: 2..20 }, allow_blank: true
   validates :content, presence: true
-  validates :content, length: { in: 5..400 }, allow_blank: true
+  validates :content, length: { in: 2..600 }, allow_blank: true
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -2,10 +2,8 @@ class Record < ApplicationRecord
   has_many :comments, dependent: :destroy
   belongs_to :user, foreign_key: "user_id"
 
-  validates :category, presence: true
-  validates :title, presence: true
-  validates :title, length: { in: 2..20 }, allow_blank: true
+  validates :theme, presence: true
+  validates :theme, length: { in: 2..20 }, allow_blank: true
   validates :content, presence: true
   validates :content, length: { in: 5..400 }, allow_blank: true
-  enum category: { episode: 0, success_story: 1, failure_story: 2 }
 end

--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -6,7 +6,7 @@ class Record < ApplicationRecord
 
   validates :tag_ids, presence: true
   validates :theme, presence: true
-  validates :theme, length: { in: 2..20 }, allow_blank: true
+  validates :theme, length: { in: 2..40 }, allow_blank: true
   validates :content, presence: true
   validates :content, length: { in: 2..600 }, allow_blank: true
 end

--- a/app/models/record_tag.rb
+++ b/app/models/record_tag.rb
@@ -1,0 +1,5 @@
+class RecordTag < ApplicationRecord
+  belongs_to :record
+  belongs_to :tag
+  validates :record_id, uniqueness: { scope: :tag_id }
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,6 @@
+class Tag < ApplicationRecord
+  has_many :record_tags, dependent: :destroy
+  has_many :records, through: :record_tags
+  validates :name, presence: true
+  validates :name, length: { in: 1..10 }, uniqueness: true, allow_blank: true
+end

--- a/app/views/letters/new.html.slim
+++ b/app/views/letters/new.html.slim
@@ -7,8 +7,8 @@
       = f.label :message, Letter.human_attribute_name(:message), class: 'mb-2'
       = f.text_area :message, autofocus: true, class: "form-control", rows: 15
     .form-group.mb-3
-      = f.label :dig_notice, Letter.human_attribute_name(:dig_notice), class: 'mb-2'
+      = f.label :send_at, Letter.human_attribute_name(:send_at), class: 'mb-2'
       br
-      = raw sprintf(f.date_select(:dig_notice, prompt: "--", use_month_numbers: true, start_year: Date.today.year, end_year: (Date.today >> 12).year, date_separator: '%s'),'年','月')+'日'
+      = raw sprintf(f.date_select(:send_at, prompt: "--", use_month_numbers: true, start_year: Date.today.year, end_year: (Date.today >> 12).year, date_separator: '%s'),'年','月')+'日'
     .action.mb-5
       = f.submit '作成', class: 'btn btn-outline-light'

--- a/app/views/records/_record.html.slim
+++ b/app/views/records/_record.html.slim
@@ -1,5 +1,12 @@
-.bg-white.mb-3.p-3.rounded-3
-  p.mb-1.small.text-muted= record.created_at.strftime("%Y年 %-m月 %-d日")
+= javascript_pack_tag 'records/index'
+
+.bg-white.mb-3.p-3.rounded-3{ style= "position: relative" }
+  .dropdown-content.mt-4.me-3.py-2.px-4.border.border-1.border-dark.rounded-2{ id= "#{record.id}" }
+    = link_to '削除', record_path(record), class: "text-dark", data: {method: :delete, confirm: '削除しても良いですか？'}
+  .d-flex.justify-content-between.px-1.text-muted
+    p.mb-1.small= record.created_at.strftime("%Y年 %-m月 %-d日")
+    .dropdown{ id= "#{record.id}" }
+      i.fa.fa-ellipsis-h.lh-1
   p#record-border.border-bottom.border-2.rounded.mb-2
   = link_to record_path(record)
     h5.mb-3.fw-bold.d-inline-block.link{ style= "color: #3683ff" }= safe_join(record.theme.split("\n"),tag(:br))

--- a/app/views/records/_record.html.slim
+++ b/app/views/records/_record.html.slim
@@ -2,7 +2,7 @@
 
 .bg-white.mb-3.p-3.rounded-3{ style= "position: relative" }
   .dropdown-content.mt-4.me-3.py-2.px-4.border.border-1.border-dark.rounded-2{ id= "#{record.id}" }
-    = link_to '削除', record_path(record), class: "text-dark", data: {method: :delete, confirm: '削除しても良いですか？'}
+    = link_to t('records.index.delete'), record_path(record), class: "text-dark", data: {method: :delete, confirm: t('records.index.delete_confirm')}
   .d-flex.justify-content-between.px-1.text-muted
     p.mb-1.small= record.created_at.strftime("%Y年 %-m月 %-d日")
     .dropdown{ id= "#{record.id}" }

--- a/app/views/records/_record.html.slim
+++ b/app/views/records/_record.html.slim
@@ -1,8 +1,10 @@
 .bg-white.mb-3.p-3.rounded-3
   p.mb-1.small.text-muted= record.created_at.strftime("%Y年 %-m月 %-d日")
   p#record-border.border-bottom.border-2.rounded.mb-2
-  h5.mb-3.fw-bold= safe_join(record.theme.split("\n"),tag(:br))
+  = link_to record_path(record)
+    h5.mb-3.fw-bold.d-inline-block.link{ style= "color: #3683ff" }= safe_join(record.theme.split("\n"),tag(:br))
   .d-flex.justify-content-start.lh-1.text-muted.mb-2
     i.fa.fa-tags.me-1
-    - record.tags.each do |tag|
-      span.me-2= tag.name
+    .d-flex.flex-wrap.
+      - record.tags.each do |tag|
+        span.me-2= tag.name

--- a/app/views/records/_record.html.slim
+++ b/app/views/records/_record.html.slim
@@ -1,0 +1,8 @@
+.bg-white.mb-3.p-3.rounded-3
+  p.mb-1.small.text-muted= record.created_at.strftime("%Y年 %-m月 %-d日")
+  p#record-border.border-bottom.border-2.rounded.mb-2
+  h5.mb-3.fw-bold= safe_join(record.theme.split("\n"),tag(:br))
+  .d-flex.justify-content-start.lh-1.text-muted.mb-2
+    i.fa.fa-tags.me-1
+    - record.tags.each do |tag|
+      span.me-2= tag.name

--- a/app/views/records/index.html.slim
+++ b/app/views/records/index.html.slim
@@ -1,0 +1,5 @@
+.container.mx-auto.py-4
+  .text-center.py-1
+    h3.mb-3
+      = t('records.index.title')
+  = render @records

--- a/app/views/records/index.html.slim
+++ b/app/views/records/index.html.slim
@@ -1,5 +1,4 @@
-.container.mx-auto.py-4
-  .text-center.py-1
-    h3.mb-3
-      = t('records.index.title')
-  = render @records
+= render 'shared/record_menu'
+.wrapper
+  .container.mx-auto.py-4
+    = render @records

--- a/app/views/records/index.html.slim
+++ b/app/views/records/index.html.slim
@@ -1,4 +1,8 @@
 = render 'shared/record_menu'
 .wrapper
   .container.mx-auto.py-4
+    .my-2.d-flex.justify-content-end
+      = form_tag records_path, method: :get do
+        = select_tag :tag_id, options_from_collection_for_select(Tag.all, :id, :name, params[:tag_id]),
+          { prompt: t('records.index.select_tag'), onchange: 'submit(this.form);' }
     = render @records

--- a/app/views/records/new.html.slim
+++ b/app/views/records/new.html.slim
@@ -4,12 +4,8 @@
         = t('records.new.title')
   = form_with model: @record, local: true do |f|
     .form-group.mb-3
-      = f.label :category, Record.human_attribute_name(:category), class: 'mb-2'
-      br
-      = f.select :category, [[t('records.new.episode'), "episode"], [t('records.new.success_story'), "success_story"], [t('records.new.failure_story'), "failure_story"]], include_blank: "カテゴリーを選択"
-    .form-group.mb-3
-      = f.label :title, Record.human_attribute_name(:title), class: 'mb-2'
-      = f.text_field :title, autofocus: true, class: "form-control"
+      = f.label :theme, Record.human_attribute_name(:theme), class: 'mb-2'
+      = f.text_field :theme, autofocus: true, class: "form-control"
     .form-group.mb-3
       = f.label :content, Record.human_attribute_name(:content), class: 'mb-2'
       = f.text_area :content, autofocus: true, class: "form-control", rows: 10

--- a/app/views/records/new.html.slim
+++ b/app/views/records/new.html.slim
@@ -1,21 +1,20 @@
-.container.mx-auto.py-4
-  .text-center.py-1
-    h3.mb-3
-      = t('records.new.title')
-  = form_with model: @record, local: true do |f|
-    .form-group.mb-3
-      = f.label :tags, Record.human_attribute_name(:tags)
-      br
-      .ms-3= f.collection_check_boxes :tag_ids, Tag.all, :id, :name, include_hidden: false do |tag|
-          = tag.label class: "form-check-label" do
-            .form-check.me-3
-              = tag.check_box class: "form-check-input"
-              = tag.text
-    .form-group.mb-3
-      = f.label :theme, Record.human_attribute_name(:theme), class: 'mb-2'
-      = f.text_area :theme, autofocus: true, class: "form-control", rows: 2
-    .form-group.mb-3
-      = f.label :content, Record.human_attribute_name(:content), class: 'mb-2'
-      = f.text_area :content, autofocus: true, class: "form-control", rows: 10
-    .action
-      = f.submit '作成', class: 'btn btn-outline-light'
+= render 'shared/record_menu'
+.wrapper
+  .container.mx-auto.py-4
+    = form_with model: @record, local: true do |f|
+      .form-group.mb-3
+        = f.label :tags, Record.human_attribute_name(:tags)
+        br
+        .ms-3= f.collection_check_boxes :tag_ids, Tag.all, :id, :name, include_hidden: false do |tag|
+            = tag.label class: "form-check-label" do
+              .form-check.me-3
+                = tag.check_box class: "form-check-input"
+                = tag.text
+      .form-group.mb-3
+        = f.label :theme, Record.human_attribute_name(:theme), class: 'mb-2'
+        = f.text_area :theme, autofocus: true, class: "form-control", rows: 2
+      .form-group.mb-3
+        = f.label :content, Record.human_attribute_name(:content), class: 'mb-2'
+        = f.text_area :content, autofocus: true, class: "form-control", rows: 10
+      .action
+        = f.submit '作成', class: 'btn btn-outline-light'

--- a/app/views/records/new.html.slim
+++ b/app/views/records/new.html.slim
@@ -1,7 +1,7 @@
 .container.mx-auto.py-4
   .text-center.py-1
-      h3.mb-3
-        = t('records.new.title')
+    h3.mb-3
+      = t('records.new.title')
   = form_with model: @record, local: true do |f|
     .form-group.mb-3
       = f.label :tags, Record.human_attribute_name(:tags)
@@ -13,7 +13,7 @@
               = tag.text
     .form-group.mb-3
       = f.label :theme, Record.human_attribute_name(:theme), class: 'mb-2'
-      = f.text_field :theme, autofocus: true, class: "form-control"
+      = f.text_area :theme, autofocus: true, class: "form-control", rows: 2
     .form-group.mb-3
       = f.label :content, Record.human_attribute_name(:content), class: 'mb-2'
       = f.text_area :content, autofocus: true, class: "form-control", rows: 10

--- a/app/views/records/new.html.slim
+++ b/app/views/records/new.html.slim
@@ -4,6 +4,14 @@
         = t('records.new.title')
   = form_with model: @record, local: true do |f|
     .form-group.mb-3
+      = f.label :tags, Record.human_attribute_name(:tags)
+      br
+      .ms-3= f.collection_check_boxes :tag_ids, Tag.all, :id, :name, include_hidden: false do |tag|
+          = tag.label class: "form-check-label" do
+            .form-check.me-3
+              = tag.check_box class: "form-check-input"
+              = tag.text
+    .form-group.mb-3
       = f.label :theme, Record.human_attribute_name(:theme), class: 'mb-2'
       = f.text_field :theme, autofocus: true, class: "form-control"
     .form-group.mb-3

--- a/app/views/records/show.html.slim
+++ b/app/views/records/show.html.slim
@@ -1,7 +1,16 @@
-.container.mx-auto{ style= "margin-bottom: 62px" }
-  i.fa.fa-backward.mt-3.ms-2.me-2.text-light
-  = link_to records_path
-    span.d-inline-block.link{ style= "color: white" }= t('records.show.back')
+= javascript_pack_tag 'records/show'
+
+.container.mx-auto{ style= "margin-bottom: 62px; position: relative;" }
+  .dropdown-content.mt-4.me-4.py-2.px-4.border.border-1.border-dark.rounded-2
+    = link_to '削除', record_path(@record), class: "text-dark", data: {method: :delete, confirm: '削除しても良いですか？'}
+  .d-flex.justify-content-between.mx-2.mt-3.text-light
+    div
+      i.fa.fa-backward.me-2
+      = link_to records_path
+        span.d-inline-block.link{ style= "color: white" }= t('records.show.back')
+    .dropdown.me-2
+      i.fa.fa-ellipsis-h
+
   .py-2
     .py-1.px-3
       h4.mb-3= safe_join(@record.theme.split("\n"),tag(:br))

--- a/app/views/records/show.html.slim
+++ b/app/views/records/show.html.slim
@@ -1,7 +1,7 @@
 .container.mx-auto.py-5
   .text-center.py-1
     h4.mb-3
-      = @record.title
+      = @record.theme
   .text-left.mx-3
     p.text-light.my-2= t('records.show.date')
     p.px-4= @record.created_at.strftime("%Y年 %-m月 %-d日")

--- a/app/views/records/show.html.slim
+++ b/app/views/records/show.html.slim
@@ -1,9 +1,12 @@
-.container.mx-auto.py-5
-  .text-center.py-1
-    h4.mb-3
-      = @record.theme
-  .text-left.mx-3
-    p.text-light.my-2= t('records.show.date')
-    p.px-4= @record.created_at.strftime("%Y年 %-m月 %-d日")
-    p.text-light.my-2= t('records.show.content')
-    p.px-4= safe_join(@record.content.split("\n"),tag(:br))
+.container.mx-auto{ style= "margin-bottom: 62px" }
+  i.fa.fa-backward.mt-3.ms-2.me-2.text-light
+  = link_to records_path
+    span.d-inline-block.link{ style= "color: white" }= t('records.show.back')
+  .py-2
+    .py-1.px-3
+      h4.mb-3= safe_join(@record.theme.split("\n"),tag(:br))
+    .text-left.mx-2
+      p.text-light.my-2= t('records.show.date')
+      p.px-4= @record.created_at.strftime("%Y年 %-m月 %-d日")
+      p.text-light.my-2= t('records.show.content')
+      p.px-4= safe_join(@record.content.split("\n"),tag(:br))

--- a/app/views/shared/_after_login_footer.html.slim
+++ b/app/views/shared/_after_login_footer.html.slim
@@ -4,5 +4,5 @@ footer.fixed-bottom
       p.d-inline-block.small.mb-0= t('shared.footer.profile')
     = link_to new_letter_path, class: "w-100 text-center py-4 #{footer_menu('letters')}"
       p.d-inline-block.small.mb-0= t('shared.footer.letter')
-    = link_to new_record_path, class: "w-100 text-center py-4 #{footer_menu('records')}"
+    = link_to records_path, class: "w-100 text-center py-4 #{footer_menu('records')}"
       p.d-inline-block.small.mb-0= t('shared.footer.record')

--- a/app/views/shared/_record_menu.html.slim
+++ b/app/views/shared/_record_menu.html.slim
@@ -1,0 +1,6 @@
+.fixed-top.record_header
+  .d-flex.flex-nowrap.bg-white.mb-0.text
+    = link_to records_path, class: "w-100 text-center py-4 #{record_menu('index')}"
+      p.d-inline-block.small.mb-0= t('shared.record.index')
+    = link_to new_record_path, class: "w-100 text-center py-4 #{record_menu('new')}"
+      p.d-inline-block.small.mb-0= t('shared.record.new')

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,4 +1,3 @@
-
 = javascript_pack_tag 'users/show'
 
 .container.mx-auto.py-5
@@ -27,13 +26,3 @@
       .text-center.small
         p.mb-0= t('users.show.count')
         p.text-dark= t('users.show.record_unit', count: @records.count)
-      .d-flex.justify-content-evenly.px-3.mb-3.text-center.small
-        .w-100
-          p.mb-0= t('users.show.episode')
-          p.text-dark= t('users.show.record_unit', count: 1)
-        .w-100
-          p.mb-0= t('users.show.success_story')
-          p.text-dark= t('users.show.record_unit', count: 3)
-        .w-100
-          p.mb-0= t('users.show.failure_story')
-          p.text-dark= t('users.show.record_unit', count: 3)

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -18,11 +18,11 @@
         p.text-dark= t('users.show.letter_unit', count: @letters.count)
       .d-flex.justify-content-evenly.px-3.mb-3.text-center.small
         .w-80
-          p.mb-0= t('users.show.not_already_letter')
-          p.text-dark= t('users.show.letter_unit', count: 1)
+          p.mb-0= t('users.show.sent_letter')
+          p.text-dark= t('users.show.letter_unit', count: @letters.sent.count)
         .w-80
-          p.mb-0= t('users.show.already_letter')
-          p.text-dark= t('users.show.letter_unit', count: 3)
+          p.mb-0= t('users.show.not_sent_letter')
+          p.text-dark= t('users.show.letter_unit', count: @letters.not_sent.count)
     .record-field
       .text-center.small
         p.mb-0= t('users.show.count')

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -22,7 +22,8 @@
         .w-80
           p.mb-0= t('users.show.not_sent_letter')
           p.text-dark= t('users.show.letter_unit', count: @letters.not_sent.count)
-    .record-field
+    .record-field.mb-3
       .text-center.small
         p.mb-0= t('users.show.count')
         p.text-dark= t('users.show.record_unit', count: @records.count)
+      = link_to t('users.show.records_path'), records_path, class: 'btn btn-outline-dark'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -5,9 +5,8 @@ ja:
       record: 記録
     attributes:
       record:
-        category: 記録のカテゴリー
-        title: 記録のタイトル
-        content: 記録の内容
+        theme: テーマ
+        content: 内容
       letter:
         message: 'メッセージ'
         send_at: '送付日'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -10,4 +10,4 @@ ja:
         content: 記録の内容
       letter:
         message: 'メッセージ'
-        dig_notice: 'お届け日'
+        send_at: '送付日'

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -7,6 +7,8 @@ ja:
       record:
         theme: テーマ
         content: 内容
+        tags: タグ
+        tag_ids: タグ
       letter:
         message: 'メッセージ'
         send_at: '送付日'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -29,6 +29,9 @@ ja:
   records:
     index:
       title: 記録一覧
+      select_tag: 全て
+      delete: 削除
+      delete_confirm: 削除してもよろしいですか？
     new:
       title: 記録の作成
       episode: エピソード

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -35,14 +35,18 @@ ja:
       success_story: 成功談
       failure_story: 失敗談
     show:
-      date: '作成日'
-      content: '内容'
+      date: 作成日
+      content: 内容
+      back: 一覧へ戻る
   letters:
     new:
       title: 手紙の作成
   shared:
+    record:
+      index: 記録の一覧
+      new: 記録の作成
     footer:
       footer_app_name: © 2022. レタレコ
       profile: プロフィール
-      letter: 手紙を作成
-      record: 記録を作成
+      letter: 手紙
+      record: 記録

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -25,7 +25,10 @@ ja:
       failure_story: 失敗談
       letter_unit: '%{count}通'
       record_unit: '%{count}件'
+      records_path: 記録一覧へ
   records:
+    index:
+      title: 記録一覧
     new:
       title: 記録の作成
       episode: エピソード

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -18,8 +18,8 @@ ja:
       letter: 手紙
       record: 記録
       count: 総数
-      not_already_letter: 未送付
-      already_letter: 送付済
+      not_sent_letter: 未送付
+      sent_letter: 送付済
       episode: エピソード
       success_story: 成功談
       failure_story: 失敗談

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,6 @@ Rails.application.routes.draw do
   post 'letters/logedin', to: 'letters#logedin'
   post '/callback' => 'linebot#callback'
   resource :user, only: %i[show create]
-  resources :records, only: %i[index show new create]
+  resources :records, only: %i[index show new create destroy]
   resources :letters, only: %i[new create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
   get 'letters/login', to: 'letters#login'
   post 'letters/logedin', to: 'letters#logedin'
   post '/callback' => 'linebot#callback'
-  resource :user, only: %i[new show create]
-  resources :records, only: %i[show new create]
+  resource :user, only: %i[show create]
+  resources :records, only: %i[index show new create]
   resources :letters, only: %i[new create]
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -7,7 +7,7 @@ set :environment, rails_env
 # cronのログの吐き出し場所
 set :output, "#{Rails.root}/log/cron.log"
 
-# 毎朝9時届け日に該当する手紙を送る
-every 1.day, at: ['9:00 am'] do
+# 毎朝9時に届け日に該当する手紙を送る
+every 1.day, at: '9:00 am' do
   rake 'letter_summary:send_letter'
 end

--- a/db/migrate/20220410072037_create_letters.rb
+++ b/db/migrate/20220410072037_create_letters.rb
@@ -3,7 +3,7 @@ class CreateLetters < ActiveRecord::Migration[6.1]
     create_table :letters do |t|
       t.references :user, null: false, foreign_key: true
       t.text :message, null: false
-      t.date :dig_notice,
+      t.date :send_at, null: false
 
       t.timestamps
     end

--- a/db/migrate/20220410072306_create_records.rb
+++ b/db/migrate/20220410072306_create_records.rb
@@ -2,8 +2,7 @@ class CreateRecords < ActiveRecord::Migration[6.1]
   def change
     create_table :records do |t|
       t.references :user, null: false, foreign_key: true
-      t.integer :category, null: false, default: 0
-      t.string :title, null: false
+      t.string :theme, null: false
       t.text :content, null: false
 
       t.timestamps

--- a/db/migrate/20220422044643_create_tags.rb
+++ b/db/migrate/20220422044643_create_tags.rb
@@ -1,0 +1,8 @@
+class CreateTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220422044841_create_record_tags.rb
+++ b/db/migrate/20220422044841_create_record_tags.rb
@@ -1,0 +1,10 @@
+class CreateRecordTags < ActiveRecord::Migration[6.1]
+  def change
+    create_table :record_tags do |t|
+      t.references :record, foreign_key: true
+      t.references :tag, foreign_key: true
+      t.timestamps
+    end
+    add_index :record_tags, [:record_id, :tag_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_10_072446) do
+ActiveRecord::Schema.define(version: 2022_04_22_044841) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,16 @@ ActiveRecord::Schema.define(version: 2022_04_10_072446) do
     t.index ["user_id"], name: "index_letters_on_user_id"
   end
 
+  create_table "record_tags", force: :cascade do |t|
+    t.bigint "record_id"
+    t.bigint "tag_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["record_id", "tag_id"], name: "index_record_tags_on_record_id_and_tag_id", unique: true
+    t.index ["record_id"], name: "index_record_tags_on_record_id"
+    t.index ["tag_id"], name: "index_record_tags_on_tag_id"
+  end
+
   create_table "records", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "theme", null: false
@@ -41,6 +51,12 @@ ActiveRecord::Schema.define(version: 2022_04_10_072446) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_records_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", force: :cascade do |t|
@@ -52,5 +68,7 @@ ActiveRecord::Schema.define(version: 2022_04_10_072446) do
   add_foreign_key "comments", "records"
   add_foreign_key "comments", "users"
   add_foreign_key "letters", "users"
+  add_foreign_key "record_tags", "records"
+  add_foreign_key "record_tags", "tags"
   add_foreign_key "records", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,8 +36,7 @@ ActiveRecord::Schema.define(version: 2022_04_10_072446) do
 
   create_table "records", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.integer "category", default: 0, null: false
-    t.string "title", null: false
+    t.string "theme", null: false
     t.text "content", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -28,10 +28,9 @@ ActiveRecord::Schema.define(version: 2022_04_10_072446) do
   create_table "letters", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.text "message", null: false
+    t.date "send_at", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.date "dig_notice"
-    t.date "#<ActiveRecord::ConnectionAdapters::PostgreSQL::TableDefinition"
     t.index ["user_id"], name: "index_letters_on_user_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,9 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+Tag.create(name: '幸せ')
+Tag.create(name: '怒り')
+Tag.create(name: '悲しみ')
+Tag.create(name: '楽しみ')
+Tag.create(name: '起床後')
+Tag.create(name: '就寝前')
+Tag.create(name: 'メンタルヘルス')
+Tag.create(name: '自己分析')
+Tag.create(name: 'アイデア')

--- a/lib/tasks/letter_summary.rake
+++ b/lib/tasks/letter_summary.rake
@@ -1,7 +1,7 @@
 namespace :letter_summary do
   desc '本日の日付が手紙の届け日時になった時、その日のam9:00に該当する手紙を送信する'
 	task send_letter: :environment do
-		@letters = Letter.dig_noticed
+		@letters = Letter.sent
 		@letters.each do |letter|
 			user = User.find_by(id: letter.user_id)
 			message = {


### PR DESCRIPTION
## 実装内容

* 修正：手紙の送付日のカラムを変更、scope設定、cronの再設定 https://github.com/O-H-K-N/line-capsule/pull/26/commits/186a0c9c6e890da0b32fec9a1ecfc94d214f1b84 
* 修正：記録のカテゴリーを削除、記録のカラムtitle→themeに修正 https://github.com/O-H-K-N/line-capsule/pull/26/commits/227bd89e9cc807304f96f3140954c020f1f5a602 
* 追加：タグのDBとモデルを作成 https://github.com/O-H-K-N/line-capsule/pull/26/commits/9b07d3ca9bf7863b03d2506526f9901281b851fb
* 追加：記録の作成フォームにタグ選択欄を追加 https://github.com/O-H-K-N/line-capsule/pull/26/commits/8a55e810bcc9f61997613d0897ebb2fdde1321ce 
* 修正：FontAwesomeが使えるように修正＋α https://github.com/O-H-K-N/line-capsule/pull/26/commits/aa1a61eb720bde9083865d73b5ea1df5d24f65ba 
* 追加：記録の一覧ページを作成 https://github.com/O-H-K-N/line-capsule/pull/26/commits/5996c94e7eb497c7c2caa46af1a74755b0af259f 
* 追加：記録関連のページの時に表示されるヘッダーに切り替えメニューを設け、一覧と作成を見やすく https://github.com/O-H-K-N/line-capsule/pull/26/commits/7b89fac682a5464040d4dffe5c9c3f6a617e895d 
* 追加：各記録にドロップメニューを設け、削除処理を実装 https://github.com/O-H-K-N/line-capsule/pull/26/commits/2430d3255e1cf86e88a35c55c907746cbde9d68f 
* 追加：記録一覧にタグ検索機能の実装 https://github.com/O-H-K-N/line-capsule/pull/26/commits/19411b397df6de544adcc43676dbaf99650b5c6b 

## 未実装内容

* 記録の更新機能は実装しない

## できるようになること（ユーザ目線）

* 自分が作成した記録一覧を確認できる
* 記録をタグごとで確認できる
* 記録を削除できる

## できなくなること（ユーザ目線）

* 記録の更新、修正
