### PR TITLE
ボタン等をFontAwesomeのアイコンに変更

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -63,3 +63,18 @@ body {
     }
   }
 }
+
+.btn-original{
+  color: yellow;
+  opacity: 0.8;
+  padding: 2px;
+  background: none;
+  border: none;
+  position: fixed;
+  bottom: 90px;
+  right: 12px;
+
+  i{
+    text-shadow: 2px 2px 1px rgba(0, 0, 0, 0.3);
+  }
+}

--- a/app/views/comments/_comment.html.slim
+++ b/app/views/comments/_comment.html.slim
@@ -4,4 +4,4 @@
     = link_to comment_path(comment), class: "text-muted", method: :delete, data: { confirm: t('defaults.delete_confirm')}, remote: true do
       i.fa.fa-trash
   p#record-border.border-bottom.border-2.rounded.mb-2
-  p.mb-2= safe_join(comment.content.split("\n"),tag(:br))
+  p.small.px-2.mb-1= safe_join(comment.content.split("\n"),tag(:br))

--- a/app/views/comments/_form.html.slim
+++ b/app/views/comments/_form.html.slim
@@ -7,5 +7,8 @@
           .mb-3
             = f.text_area :content, autofocus: true, class: "form-control", rows: 6
         .modal-footer
-          = f.submit t('defaults.add'), class: 'btn btn-outline-primary'
-          button.btn.btn-secondary{ type= "button" data-bs-dismiss="modal"}= t('defaults.close')
+          / = f.submit t('defaults.add'), class: 'btn btn-outline-primary'
+          = button_tag type: 'submit', class: 'btn btn-outline-primary' do
+            i.fa.fa-paper-plane.fa-lg.m-0.p-1
+          button.btn.btn-outline-secondary{ type= "button" data-bs-dismiss="modal"}
+            i.fa.fa-times.fa-lg.m-0.px-1

--- a/app/views/records/index.html.slim
+++ b/app/views/records/index.html.slim
@@ -6,3 +6,6 @@
         = select_tag :tag_id, options_from_collection_for_select(Tag.all, :id, :name, params[:tag_id]),
           { prompt: t('records.index.select_tag'), onchange: 'submit(this.form);' }
     = render @records
+  = link_to  new_record_path
+    button.btn-original{ type= "button" data-bs-toggle="modal" data-bs-target="#newRecordModal" }
+      i.fa.fa-plus-circle.fa-3x

--- a/app/views/records/new.html.slim
+++ b/app/views/records/new.html.slim
@@ -6,10 +6,10 @@
         = f.label :tags, Record.human_attribute_name(:tags)
         br
         .ms-3= f.collection_check_boxes :tag_ids, Tag.all, :id, :name, include_hidden: false do |tag|
-            = tag.label class: "form-check-label" do
-              .form-check.me-3
-                = tag.check_box class: "form-check-input"
-                = tag.text
+          = tag.label class: "form-check-label" do
+            .form-check.me-3
+              = tag.check_box class: "form-check-input"
+              = tag.text
       .form-group.mb-3
         = f.label :theme, Record.human_attribute_name(:theme), class: 'mb-2'
         = f.text_area :theme, autofocus: true, class: "form-control", rows: 2
@@ -17,4 +17,5 @@
         = f.label :content, Record.human_attribute_name(:content), class: 'mb-2'
         = f.text_area :content, autofocus: true, class: "form-control", rows: 10
       .action.mb-3.d-flex.justify-content-end
-        = f.submit t('defaults.create'), class: 'btn btn-outline-light'
+        = button_tag type: 'submit', class: 'btn btn-outline-dark' do
+          i.fa.fa-paper-plane-o.fa-lg.m-0.px-3

--- a/app/views/records/show.html.slim
+++ b/app/views/records/show.html.slim
@@ -19,7 +19,7 @@
       p.text-light.my-2= t('records.show.comment_index')
       #js-comment-area.mb-3
         = render @comments
-      .d-flex.justify-content-end.me-2
-        button.btn.btn-outline-dark{ type= "button" data-bs-toggle="modal" data-bs-target="#newRecordModal" }= t('records.show.comment_new')
+      button.btn-original{ type= "button" data-bs-toggle="modal" data-bs-target="#newRecordModal" }
+        i.fa.fa-plus-circle.fa-3x
   / コメントフォーム
   = render 'comments/form', record: @record, comment: @comment


### PR DESCRIPTION
## 実装内容

- 修正：https://github.com/O-H-K-N/line-capsule/pull/33/commits/d29ae74143621976913bacc58677d73f93a04d72 
  - 修正：FontAwesomeのボタンからコメント追加モーダルが表示されるように変更
  - 修正：FontAwesomeのボタンから記録作成ページが表示されるように変更
