### PR TITLE
オンラインもくもく会の自動通知機能を実装

### DIFF
--- a/app/controllers/linebot_controller.rb
+++ b/app/controllers/linebot_controller.rb
@@ -39,6 +39,8 @@ class LinebotController < ApplicationController
         case
         # 新着順を選択した場合
         when data.include?("new_")
+          message = {type: 'text', text: 'イベント探索中・・・'}
+          client.push_message(line_user_id, message)
           case
           when data.include?("オンラインもくもく会")
             # オンラインともくもく会でイベントを取得(日付は本日、順序は開催が近い順)
@@ -55,6 +57,8 @@ class LinebotController < ApplicationController
           events = events.reverse.compact
         # ランダムを選択した場合
         when data.include?("randam_")
+          message = {type: 'text', text: 'イベント探索中・・・'}
+          client.push_message(line_user_id, message)
           case
           when data.include?("オンラインもくもく会")
             # オンラインともくもく会でイベントを取得
@@ -75,35 +79,28 @@ class LinebotController < ApplicationController
         # 取得したイベントの数が0のとき
         when 0
           client.reply_message(event['replyToken'], type: 'text', text: '該当するイベントが見つかりませんでした。')
-        # 取得したイベントの数が1のとき
-        when 1
-          message = User.set_events(events[0])
-          client.reply_message(event['replyToken'], [{ type: 'text', text: 'イベントは１件あります。'}, message])
-        # 取得したイベントの数が2のとき
-        when 2
-          message_1 = User.set_events(events[0])
-          message_2 = User.set_events(events[1])
-          client.reply_message(event['replyToken'], [{ type: 'text', text: 'イベントは２件あります。'}, message_1, message_2])
-        # 取得したイベントの数が3のとき
-        when 3
-          message_1 = User.set_events(events[0])
-          message_2 = User.set_events(events[1])
-          message_3 = User.set_events(events[2])
-          client.reply_message(event['replyToken'], [{ type: 'text', text: 'イベントは３件あります。'}, message_1, message_2, message_3])
-        # 取得したイベントの数が4以上のとき
-        when 4..nil
-          message_1 = User.set_events(events[0])
-          message_2 = User.set_events(events[1])
-          message_3 = User.set_events(events[2])
-          message_4 = User.set_events(events[3])
-          client.reply_message(event['replyToken'], [{ type: 'text', text: 'イベントは４件以上あります。'}, message_1, message_2, message_3, message_4])
+        # 取得したイベントの数が5件以上のとき
+        when 5..nil
+          client.reply_message(event['replyToken'], [{ type: 'text', text: 'イベントが5件以上見つかりました✨'}])
+          events = events.first(5)
+          events.each do |event|
+            message = User.set_events(event)
+            client.push_message(line_user_id, message)
+          end
+        # 取得したイベントの数が5件未満のとき
+        else
+          client.reply_message(event['replyToken'], [{ type: 'text', text: "イベントが#{events.length}件見つかりました✨"}])
+          events.each do |event|
+            message = User.set_events(event)
+            client.push_message(line_user_id, message)
+          end
         end
       end
     }
     head :ok
   end
 
-private
+  private
 
   # LINE Developers登録完了後に作成される環境変数の認証
   def client

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -116,7 +116,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:line_id, :account, :prefecture, :count)
+    params.require(:user).permit(:line_id, :account, :prefecture, :count, :checked)
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   validates :account, presence: true, on: :update
   validates :prefecture, presence: true, on: :update
   validates :count, presence: true, on: :update
+  validates :checked, inclusion: [true, false]
 
   enum prefecture:{
     北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,13 @@ class User < ApplicationRecord
     沖縄県:47
   }
 
+  # ラインクライアントに接続するメソッド
+  def self.line_client
+    Line::Bot::Client.new { |config|
+      config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+    }
+  end
 
   # connpassのイベント取得メソッド
   def self.get_events(url)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,6 +10,7 @@ html
     = Gon::Base.render_data
     = stylesheet_link_tag 'application', media: 'all'
     = javascript_pack_tag 'application'
+    link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/JNKKKK/MoreToggles.css@0.2.1/output/moretoggles.min.css"
     script crossorigin="anonymous" src="https://kit.fontawesome.com/e1d6c1fcca.js"
     script crossorigin="anonymous" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" 
     script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js" type="text/javascript"

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,25 +1,32 @@
 
 .container.mx-auto.mt-3{ style='margin-bottom: 85px;' }
   .text-center
-    h2.mt-4.mb-3.text-muted= t('users.new.setting')
+    h2.mt-4.mb-3.text-muted= t('users.edit.setting')
   = form_with model: @user, local: true do |f|
     .mb-4= render 'shared/error_form', object: f.object
     .mb-4= render 'shared/flash_message'
     .form-group.m-2
-      = f.label :account, t('users.new.account_label') ,class: "form-label mb-1 text-muted small"
+      = f.label :account, t('users.edit.account_label') ,class: "form-label mb-1 text-muted small"
       = f.text_field :account, class: "form-control mb-3", autofocus: true
     .form-group.m-2
-      = f.label :prefecture, t('users.new.prefecture_label'), class: "form-label mb-1 text-muted small"
+      = f.label :prefecture, t('users.edit.prefecture_label'), class: "form-label mb-1 text-muted small"
       = f.select :prefecture, User.prefectures.keys, {}, class: "form-control", autofocus: true
     .form-group.m-2
-      = f.label :count, t('users.new.count_label'),class: "form-label mb-1 text-muted small"
+      = f.label :count, t('users.edit.count_label'), class: "form-label mb-1 text-muted small"
       = f.number_field :count, class: "form-control", autofocus: true, min: 10, max: 100
+    .form-group.m-2
+      = f.label :count, t('users.edit.checked_label'), class: "form-label mb-1 text-muted small"
+      br
+      .mt-ios.mt-2{ style="font-size:10px;"}
+        = f.check_box :checked, id: 1
+        label{for="1"}
     .d-flex.justify-content-end
-      .action.my-2.me-3
-        = f.submit t('users.new.submit'), class: "btn btn-dark"
+      .action.mb-2.me-3
+        = f.submit t('users.edit.submit'), class: "btn btn-dark"
 
   .m-2.small.text-muted
-    p= t('users.new.account_attention')
-    p= t('users.new.count_attention')
+    p= t('users.edit.account_attention')
+    p= t('users.edit.count_attention')
+    p= t('users.edit.checked_attention')
 
 = render 'shared/after_login_footer'

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,7 @@ module LineCapsule
 
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    # レイアウト崩れを防ぐ
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
   end
 end

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,6 +1,6 @@
 ja:
   defaults:
-    app_name: レタレコ
+    app_name: connpassもくもく会Bot
     how_to_use: 使い方
     contact: お問い合わせ
     term: 利用規約
@@ -26,14 +26,16 @@ ja:
       before_events: 開催前
       after_events: 開催後
       venue_undecided: 会場未定
-    new:
+    edit:
       setting: 設定
       account_label: connpassのユーザー名（※1）
       prefecture_label: 住んでいる都道府県
       count_label: 予約イベントの表示数（※2）
+      checked_label: オンラインもくもく会の通知ON/OFF（※3）
       submit: '確定'
       account_attention: ※1：正しいユーザー名を登録しない場合、異なる予約イベントが表示されます。
       count_attention: ※2：最小で10件、最大で100件のイベントを表示できます。
+      checked_attention: ※3：通知ONにすると、毎週月曜日の朝9時に、その週に開催されるオンラインもくもく会が通知されます。
     update:
       success: ユーザー設定を編集しました
   shared:

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,3 +6,9 @@ rails_env = ENV['RAILS_ENV'] || :development
 set :environment, rails_env
 # cronのログの吐き出し場所
 set :output, "#{Rails.root}/log/cron.log"
+
+
+# 毎朝9時に届け日に該当する手紙を送る
+every 1.day, :at => '9:00 am' do
+  rake 'connpass_summary:send_connpass'
+end

--- a/db/migrate/20220507044700_create_users.rb
+++ b/db/migrate/20220507044700_create_users.rb
@@ -4,8 +4,9 @@ class CreateUsers < ActiveRecord::Migration[6.1]
       t.string :line_id, null: false
       t.string :account
       t.integer :count, default: 10
-      t.integer :prefecture, null: false, default: 13
+      t.integer :prefecture, default: 13
       t.boolean :flag, default: false
+      t.boolean :checked, default: false
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,8 +19,9 @@ ActiveRecord::Schema.define(version: 2022_05_07_044700) do
     t.string "line_id", null: false
     t.string "account"
     t.integer "count", default: 10
-    t.integer "prefecture", default: 13, null: false
+    t.integer "prefecture", default: 13
     t.boolean "flag", default: false
+    t.boolean "checked", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/lib/tasks/connpass_summary.rake
+++ b/lib/tasks/connpass_summary.rake
@@ -1,0 +1,31 @@
+namespace :connpass_summary do
+  desc '毎週月曜am9:00に、その週に開催されるオンラインもくもく会の情報を通知する'
+	task send_connpass: :environment do
+    today = Date.today.strftime("%Y%m%d")
+    one = Date.tomorrow.strftime("%Y%m%d")
+    two = (Date.tomorrow + 1).strftime("%Y%m%d")
+    three = (Date.tomorrow + 2).strftime("%Y%m%d")
+    four = (Date.tomorrow + 3).strftime("%Y%m%d")
+    five = (Date.tomorrow + 4).strftime("%Y%m%d")
+    six = (Date.tomorrow + 5).strftime("%Y%m%d")
+    url = URI.encode"https://connpass.com/api/v1/event/?keyword=オンライン　もくもく会&count=100&order=2&ymd=#{today}&ymd=#{one}&ymd=#{two}&ymd=#{three}&ymd=#{four}&ymd=#{five}&ymd=#{six}"
+		events = User.get_events(url)
+    events = events.reverse.compact
+    # ラインクライアントに接続
+    client = User.line_client
+    # 全てのユーザのLINE IDを集約
+    user_ids = []
+    User.all.each { |user| user_ids << user.line_id }
+    manual = { type: 'text', text: '今週開催されるオンラインもくもく会の情報です。' }
+    response = client.multicast(user_ids, manual)
+    p response
+		events.each do |event|
+      message = User.set_events(event)
+      response = client.multicast(user_ids, message)
+			p response
+		end
+    count = { type: 'text', text: "以上、#{events.length}件です。" }
+    response = client.multicast(user_ids, count)
+    p response
+	end
+end


### PR DESCRIPTION
## 実装内容

* 追加：その日から１週間の間で開催されるオンラインもくもく会の情報を、全ユーザに通知する機能を実装 https://github.com/O-H-K-N/line-capsule/pull/45/commits/ae1475134b4af9bbbaf7e5dc35c7ba104abc560b 
* 修正：メッセージの送信方法をreply_messageからpush_messageに変更 https://github.com/O-H-K-N/line-capsule/pull/45/commits/565f732f10d61c61eb47cc315104c1d66ab87518 
* 追加：ユーザごとに通知設定ができるように、通知ON/OFFボタンを実装 https://github.com/O-H-K-N/line-capsule/pull/45/commits/c2814f06045e06e686b74be466cd2617e460cf24 

## できるようになること（ユーザ目線）

* ユーザは１週間ごとにオンラインもくもく会の開催情報を通知で受け取る
* 通知の受け取りは、ユーザ設定の通知ON/OFF機能で設定することができる
